### PR TITLE
removed error code console.logs as per juno instructor feedback

### DIFF
--- a/src/components/CardGame.js
+++ b/src/components/CardGame.js
@@ -43,15 +43,12 @@ const CardGame = () => {
             .catch(function (error) {
                 if (error.response) {
                   // The request was made and the server responded with a status code that falls out of the range of 2xx
-                  console.log(error.response.status);
                   setError(true);
                 } else if (error.request) {
                   // The request was made but no response was received
-                  console.log(error.request);
                   setError(true);
                 } else {
                   // Something happened in setting up the request that triggered an Error
-                  console.log('Error', error.message);
                   setError(true);
                 }
               });
@@ -69,15 +66,12 @@ const CardGame = () => {
             .catch(function (error) {
                 if (error.response) {
                   // The request was made and the server responded with a status code that falls out of the range of 2xx
-                  console.log(error.response.status);
                   setError(true);
                 } else if (error.request) {
                   // The request was made but no response was received
-                  console.log(error.request);
                   setError(true);
                 } else {
                   // Something happened in setting up the request that triggered an Error
-                  console.log('Error', error.message);
                   setError(true);
                 }
               });

--- a/src/components/DrawCard.js
+++ b/src/components/DrawCard.js
@@ -139,15 +139,12 @@ const DrawCard = (props) => {
             .catch(function (error) {
                 if (error.response) {
                 // The request was made and the server responded with a status code that falls out of the range of 2xx
-                console.log(error.response.status);
                 setError(true);
                 } else if (error.request) {
                 // The request was made but no response was received
-                console.log(error.request);
                 setError(true);
                 } else {
                 // Something happened in setting up the request that triggered an Error
-                console.log('Error', error.message);
                 setError(true);
                 }
             });


### PR DESCRIPTION
I left console.logs in on purpose for when Axios calls errored out (they would return the status code), but I've removed those as per feedback from Juno instructors.